### PR TITLE
Extend build and create methods with attributes

### DIFF
--- a/__tests__/intergation/factory.ts
+++ b/__tests__/intergation/factory.ts
@@ -86,12 +86,28 @@ describe('Factory Test', () => {
       const createdObjects = await PostFactory.createList(3);
       expect(createdObjects.length).toEqual(3);
     });
+
+    it('accepts attributes', async () => {
+      const createdObjects = await PostFactory.createList(2, {
+        postType: PostType.IMAGE
+      });
+      expect(createdObjects[0].postType).toEqual(PostType.IMAGE);
+      expect(createdObjects[1].postType).toEqual(PostType.IMAGE);
+    });
   });
 
   describe('buildList', () => {
     it('builds an array of objects', async () => {
       const createdObjects = await PostFactory.buildList(3);
       expect(createdObjects.length).toEqual(3);
+    });
+
+    it('accepts attributes', async () => {
+      const createdObjects = await PostFactory.buildList(2, {
+        postType: PostType.IMAGE
+      });
+      expect(createdObjects[0].postType).toEqual(PostType.IMAGE);
+      expect(createdObjects[1].postType).toEqual(PostType.IMAGE);
     });
   });
 

--- a/__tests__/support/cleaner.ts
+++ b/__tests__/support/cleaner.ts
@@ -2,6 +2,6 @@ import { getConnection } from 'typeorm';
 
 export const clean = () => {
   const { manager } = getConnection();
-  const names = ['comment', 'post'];
+  const names = ['comment', 'post', 'author'];
   return manager.query(names.map(name => `DELETE FROM ${name};`).join('\n'));
 };

--- a/src/AssocManyAttribute.ts
+++ b/src/AssocManyAttribute.ts
@@ -1,4 +1,4 @@
-import { Factory } from "./Factory";
+import { Factory } from './Factory';
 
 export class AssocManyAttribute<T> {
   private readonly factory: Factory<T>;

--- a/src/AssocOneAttribute.ts
+++ b/src/AssocOneAttribute.ts
@@ -1,4 +1,4 @@
-import { Factory } from "./Factory";
+import { Factory } from './Factory';
 
 export class AssocOneAttribute<T> {
   private readonly factory: Factory<T>;

--- a/src/FactoryAttribute.ts
+++ b/src/FactoryAttribute.ts
@@ -1,4 +1,3 @@
-
 export class FactoryAttribute<T> {
   private readonly attrValue: T;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4052,9 +4052,9 @@ typeorm@^0.2.7:
     yargs "^11.1.0"
 
 typescript@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Adds possibility to create multiple entities with same attributes. E.g.
```
const author = await AuthorFactory.create();
const posts = await PostFactory.createList(3, { author });
```
will create 3 posts for the same author