### PR TITLE
Allow assocOne to work with lazily loaded associations

### DIFF
--- a/__tests__/fixtures/entity/Post.ts
+++ b/__tests__/fixtures/entity/Post.ts
@@ -30,4 +30,7 @@ export class Post {
 
   @ManyToOne(() => Author, (author) => author.posts)
   public author: Author;
+
+  @ManyToOne(() => Author)
+  public coAuthor: Promise<Author>;
 }

--- a/__tests__/intergation/factory.ts
+++ b/__tests__/intergation/factory.ts
@@ -45,7 +45,8 @@ describe('Factory Test', () => {
       .attr('likesCount', 10)
       .attr('postType', PostType.TEXT)
       .assocMany('comments', CommentFactory, 2)
-      .assocOne('author', AuthorFactory);
+      .assocOne('author', AuthorFactory)
+      .assocOne('coAuthor', AuthorFactory);
 
     MostLikedPost = PostFactory.attr('likesCount', 10000);
   });
@@ -125,14 +126,30 @@ describe('Factory Test', () => {
   });
 
   describe('assocOne', () => {
-    it('builds association', () => {
-      const object = PostFactory.build();
-      expect(object.author).toBeInstanceOf(Author);
+    describe('with eagerly loaded attribute', () => {
+      it('builds association', () => {
+        const object = PostFactory.build();
+        expect(object.author).toBeInstanceOf(Author);
+      });
+
+      it('creates association', async () => {
+        const object = await PostFactory.create();
+        expect(object.author.id).toBeDefined();
+      });
     });
 
-    it('creates association', async () => {
-      const object = await PostFactory.create();
-      expect(object.author.id).toBeDefined();
+    describe('with lazily loaded attribute', () => {
+      it('builds association', async () => {
+        const object = PostFactory.build();
+        const coAuthor = await object.coAuthor;
+        expect(coAuthor).toBeInstanceOf(Author);
+      });
+
+      it('creates association', async () => {
+        const object = await PostFactory.create();
+        const coAuthor = await object.coAuthor;
+        expect(coAuthor.id).toBeDefined();
+      });
     });
   });
 

--- a/src/Factory.ts
+++ b/src/Factory.ts
@@ -1,4 +1,4 @@
-import { getRepository, Repository } from 'typeorm';
+import { DeepPartial, getRepository, Repository } from 'typeorm';
 import { AssocManyAttribute } from './AssocManyAttribute';
 import { AssocOneAttribute } from './AssocOneAttribute';
 import { FactoryAttribute } from './FactoryAttribute';
@@ -112,7 +112,7 @@ export class Factory<T> {
   /**
    * builds an instance of Entity
    */
-  public build(attributes: Partial<T> = {}): T {
+  public build(attributes: DeepPartial<T> = {}): T {
     const ignoreKeys = Object.keys(attributes);
     const obj = this.assignAttrs(new this.Entity(), ignoreKeys);
     return this.repository.merge(obj, attributes);
@@ -121,14 +121,14 @@ export class Factory<T> {
   /**
    * builds a list instances of Entity
    */
-  public buildList(size: number, attributes: Partial<T> = {}): T[] {
+  public buildList(size: number, attributes: DeepPartial<T> = {}): T[] {
     return Array.from({ length: size }, () => this.build(attributes));
   }
 
   /**
    * creates an Entity
    */
-  public async create(attributes: Partial<T> = {}): Promise<T> {
+  public async create(attributes: DeepPartial<T> = {}): Promise<T> {
     const entity = await this.createEntity(attributes);
     return this.repository.save(entity);
   }
@@ -138,7 +138,7 @@ export class Factory<T> {
    */
   public async createList(
     size: number,
-    attributes: Partial<T> = {}
+    attributes: DeepPartial<T> = {}
   ): Promise<T[]> {
     const entities = await Promise.all(
       Array.from({ length: size }, () => this.createEntity(attributes))
@@ -166,7 +166,7 @@ export class Factory<T> {
     }, Promise.resolve(obj));
   }
 
-  private async createEntity(attributes: Partial<T> = {}): Promise<T> {
+  private async createEntity(attributes: DeepPartial<T> = {}): Promise<T> {
     const ignoreKeys = Object.keys(attributes);
     const obj = await this.assignAsyncAttrs(new this.Entity(), ignoreKeys);
     return this.repository.merge(obj, attributes);

--- a/src/Factory.ts
+++ b/src/Factory.ts
@@ -102,7 +102,7 @@ export class Factory<T> {
    */
   public assocOne<K extends keyof T>(
     name: K,
-    factory: Factory<T[K]>
+    factory: Factory<T[K] extends PromiseLike<infer U> ? U : T[K]>
   ): Factory<T> {
     const clonedFactory = this.clone();
     clonedFactory.attrs.push([name, new AssocOneAttribute(factory)] as any);


### PR DESCRIPTION
Lazy loaded associations have a `Promise` type, which conflicted with the `.assocOne` parameter types.
This PR allows using factories when setting up lazy associations in `.assocOne`.
Additionally use `DeepPartial` instead of `Partial` as they are not compatible in newer versions of TypeORM.

fixes #5 